### PR TITLE
Fix GitHub Pages docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,16 +44,18 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --locked --only-dev
+          uv sync --locked --only-group doc
 
       - name: Build doc with Sphinx
         run: |
           uv run sphinx-build docs docs/_build
+          touch docs/_build/.nojekyll
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
           path: "docs/_build"
+          include-hidden-files: true
 
   deploy:
     environment:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -16,10 +16,10 @@ dapla\_auth\_client package
 =============================================================================
 
 
-dapla\_auth\_client.functions module
+dapla\_auth\_client.auth module
 -----------------------------------------------------------------------------
 
-.. automodule:: dapla_auth_client.functions
+.. automodule:: dapla_auth_client.auth
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
## Summary
- Include a .nojekyll marker in the GitHub Pages artifact
- Upload hidden files so the marker is preserved
- Fix the stale autodoc reference to the removed dapla_auth_client.functions module

## Testing
- uv sync --locked --only-group doc && uv run sphinx-build -E docs docs/_build && touch docs/_build/.nojekyll